### PR TITLE
Replace 'extern crate' by 'use'

### DIFF
--- a/graphql/src/lib.rs
+++ b/graphql/src/lib.rs
@@ -3,8 +3,8 @@ pub mod schema;
 
 pub use crate::errors::*;
 
-pub extern crate perro;
-pub extern crate reqwest;
+pub use perro;
+pub use reqwest;
 
 use graphql_client::reqwest::post_graphql_blocking;
 use graphql_client::Response;

--- a/honey-badger/src/lib.rs
+++ b/honey-badger/src/lib.rs
@@ -3,7 +3,7 @@ mod provider;
 pub mod secrets;
 mod signing;
 
-pub extern crate graphql;
+pub use graphql;
 
 pub use crate::provider::AuthLevel;
 


### PR DESCRIPTION
Since Rust edition 2018, `use` does the job, also for external crates.