### PR TITLE
[mole] Check return error when there is no data

### DIFF
--- a/graphql/src/errors.rs
+++ b/graphql/src/errors.rs
@@ -5,7 +5,8 @@ pub enum GraphQlRuntimeErrorCode {
     AuthServiceError,
     NetworkError,
     GenericError,
-    DataError,
+    CorruptData,
+    ObjectNotFound,
 }
 
 impl Display for GraphQlRuntimeErrorCode {

--- a/graphql/src/errors.rs
+++ b/graphql/src/errors.rs
@@ -5,6 +5,7 @@ pub enum GraphQlRuntimeErrorCode {
     AuthServiceError,
     NetworkError,
     GenericError,
+    DataError,
 }
 
 impl Display for GraphQlRuntimeErrorCode {

--- a/mole/src/lib.rs
+++ b/mole/src/lib.rs
@@ -95,7 +95,7 @@ impl ChannelStatePersistenceClient {
 
         if data.channel_monitor.is_empty() {
             return Err(runtime_error(
-                GraphQlRuntimeErrorCode::DataError,
+                GraphQlRuntimeErrorCode::ObjectNotFound,
                 "No channel monitor found for channel id {channel_id}",
             ));
         }
@@ -106,7 +106,7 @@ impl ChannelStatePersistenceClient {
                 .replacen("\\x", "", 1),
         )
         .map_to_runtime_error(
-            GraphQlRuntimeErrorCode::DataError,
+            GraphQlRuntimeErrorCode::CorruptData,
             "Could not decode hex encoded binary",
         )?;
 
@@ -132,7 +132,7 @@ impl ChannelStatePersistenceClient {
 
         if data.channel_manager.is_empty() {
             return Err(runtime_error(
-                GraphQlRuntimeErrorCode::DataError,
+                GraphQlRuntimeErrorCode::ObjectNotFound,
                 "No channel manager found",
             ));
         }
@@ -143,7 +143,7 @@ impl ChannelStatePersistenceClient {
                 .replacen("\\x", "", 1),
         )
         .map_to_runtime_error(
-            GraphQlRuntimeErrorCode::DataError,
+            GraphQlRuntimeErrorCode::CorruptData,
             "Could not decode hex encoded binary",
         )
     }

--- a/mole/tests/integration_tests.rs
+++ b/mole/tests/integration_tests.rs
@@ -100,7 +100,7 @@ fn test_reading_channel_monitors_when_there_are_none() {
     assert!(matches!(
         result,
         Err(RuntimeError {
-            code: GraphQlRuntimeErrorCode::DataError,
+            code: GraphQlRuntimeErrorCode::ObjectNotFound,
             ..
         })
     ));
@@ -116,7 +116,7 @@ fn test_reading_channel_manager_when_there_is_none() {
     assert!(matches!(
         result,
         Err(RuntimeError {
-            code: GraphQlRuntimeErrorCode::DataError,
+            code: GraphQlRuntimeErrorCode::ObjectNotFound,
             ..
         })
     ));

--- a/mole/tests/integration_tests.rs
+++ b/mole/tests/integration_tests.rs
@@ -1,4 +1,6 @@
 use bitcoin::Network;
+use graphql::perro::Error::RuntimeError;
+use graphql::{Error, GraphQlRuntimeErrorCode};
 use honey_badger::secrets::{derive_keys, generate_keypair, generate_mnemonic};
 use honey_badger::{Auth, AuthLevel};
 use mole::ChannelStatePersistenceClient;
@@ -80,6 +82,44 @@ fn test_channel_monitor_persistence() {
 
     let retrieved_channel_1 = client.read_channel_monitor(channel_id_1).unwrap();
     assert_eq!(retrieved_channel_1, channel_monitor_1);
+}
+
+#[test]
+fn test_reading_channel_monitors_when_there_are_none() {
+    let client = build_storage_client();
+
+    let non_existant_channel_id =
+        "33333333333333333333333333333333333333333333333333333333333333330001";
+
+    let retrieved_channel_ids = client.get_channel_monitor_ids().unwrap();
+    assert_eq!(retrieved_channel_ids.len(), 0);
+
+    let result = client.read_channel_monitor(non_existant_channel_id);
+
+    assert!(result.is_err());
+    assert!(matches!(
+        result,
+        Err(RuntimeError {
+            code: GraphQlRuntimeErrorCode::DataError,
+            ..
+        })
+    ));
+}
+
+#[test]
+fn test_reading_channel_manager_when_there_is_none() {
+    let client = build_storage_client();
+
+    let result = client.read_channel_manager();
+
+    assert!(result.is_err());
+    assert!(matches!(
+        result,
+        Err(RuntimeError {
+            code: GraphQlRuntimeErrorCode::DataError,
+            ..
+        })
+    ));
 }
 
 #[test]


### PR DESCRIPTION
Before this PR, the library panics (array out of bounds) when it wants to retrieve a `channel manager` or a `channel monitor` but there is no data.

This PR introduces proper error handling by returning a `DataError`.