### PR TITLE
[mole] Add int test to verify empty data (not Err)

### DIFF
--- a/mole/tests/integration_tests.rs
+++ b/mole/tests/integration_tests.rs
@@ -85,6 +85,14 @@ fn test_channel_monitor_persistence() {
 }
 
 #[test]
+fn test_getting_channel_monitor_ids_when_there_are_none() {
+    let client = build_storage_client();
+
+    let retrieved_channel_ids = client.get_channel_monitor_ids().unwrap();
+    assert_eq!(retrieved_channel_ids.len(), 0);
+}
+
+#[test]
 fn test_reading_channel_monitors_when_there_are_none() {
     let client = build_storage_client();
 


### PR DESCRIPTION
A specific test case for retrieving channel monitor ids was missing: Make sure that when there are no channel monitors stored, the library returns an empty vector instead of an Error.