### PR TITLE
Add RemoteServiceUnavailable test

### DIFF
--- a/graphql/src/lib.rs
+++ b/graphql/src/lib.rs
@@ -39,7 +39,8 @@ pub fn post_blocking<Query: graphql_client::GraphQLQuery>(
     let response = match post_graphql_blocking::<Query, _>(client, backend_url, variables) {
         Ok(r) => r,
         Err(e) => {
-            if is_502_status(e.status()) {
+            if is_502_status(e.status()) || e.to_string().contains("502") {
+                // checking for the error containing 502 because reqwest is unexpectedly returning a decode error instead of status error
                 return Err(runtime_error(
                     GraphQlRuntimeErrorCode::RemoteServiceUnavailable,
                     "The remote server returned status 502",

--- a/honey-badger/tests/integration_tests.rs
+++ b/honey-badger/tests/integration_tests.rs
@@ -44,6 +44,31 @@ fn test_invalid_url() {
 }
 
 #[test]
+fn test_502_return() {
+    let (wallet_keypair, auth_keypair) = generate_keys();
+
+    let auth = Auth::new(
+        "https://httpstat.us/502".to_string(),
+        AuthLevel::Pseudonymous,
+        wallet_keypair,
+        auth_keypair,
+    )
+    .unwrap();
+
+    let id = auth.get_wallet_pubkey_id();
+    assert!(id.is_none());
+
+    let result = auth.query_token();
+    assert!(matches!(
+        result,
+        Err(Error::RuntimeError {
+            code: GraphQlRuntimeErrorCode::RemoteServiceUnavailable,
+            ..
+        })
+    ));
+}
+
+#[test]
 fn test_basic_auth() {
     let (wallet_keypair, auth_keypair) = generate_keys();
 


### PR DESCRIPTION
This adds a test that fails at the moment. The issue seems to be within the `graphql_client` crate. To be investigated