### PR TITLE
Explicitly use resolver = 2 for the workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,5 @@ members = [
     "squirrel",
     "parrot",
 ]
+
+resolver = "2"


### PR DESCRIPTION
It fixes
warning: virtual workspace defaulting to `resolver = "1"` despite one or more workspace members being on edition 2021 which implies `resolver = "2"`