### PR TITLE
Derive boilerplate fns for exposed data types

### DIFF
--- a/crow/src/lib.rs
+++ b/crow/src/lib.rs
@@ -13,7 +13,7 @@ use graphql::perro::runtime_error;
 pub use isocountry::CountryCode;
 pub use isolanguage_1::LanguageCode;
 
-#[derive(Debug, PartialEq)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub enum TopupStatus {
     READY,
     FAILED,
@@ -47,6 +47,7 @@ pub enum TopupError {
     PermanentFailure { code: PermanentFailureCode },
 }
 
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct TopupInfo {
     pub id: String,
     pub status: TopupStatus,

--- a/graphql/src/lib.rs
+++ b/graphql/src/lib.rs
@@ -15,6 +15,7 @@ use reqwest::header::{HeaderValue, AUTHORIZATION};
 use reqwest::StatusCode;
 use std::time::{Duration, SystemTime};
 
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ExchangeRate {
     pub currency_code: String,
     pub sats_per_unit: u32,


### PR DESCRIPTION
I need some of these derivations for how we mock things in `lipa-lightning-lib`, but these derivations could come in handy in other contexts as well. 